### PR TITLE
fix typo in the path name

### DIFF
--- a/pyattest/testutils/factories/certificates.py
+++ b/pyattest/testutils/factories/certificates.py
@@ -49,5 +49,5 @@ def generate():
         .sign(root_private_key, hashes.SHA256())
     )
 
-    with open("pyatest/testutils/fixtures/root_cert.pem", "wb") as f:
+    with open("pyattest/testutils/fixtures/root_cert.pem", "wb") as f:
         f.write(cert.public_bytes(serialization.Encoding.PEM))


### PR DESCRIPTION
Hi, I've been playing around with iOS attest verification and I wanted to use this library to generate valid certificates for the QA, but I've noticed you have a a typo and because of that the `generate()` is failing unless I maintain 2 paths - the correctly spelled and with a typo : )

Kindly consider my PR 🙌 

